### PR TITLE
Remove Literal to use the custom validator

### DIFF
--- a/module-2/state-schema.ipynb
+++ b/module-2/state-schema.ipynb
@@ -384,7 +384,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "62e8720e-217f-4b98-837a-af45c3fa577f",
    "metadata": {},
    "outputs": [
@@ -404,7 +404,7 @@
     "\n",
     "class PydanticState(BaseModel):\n",
     "    name: str\n",
-    "    mood: Literal[\"happy\", \"sad\"]\n",
+    "    mood: str # \"happy\" or \"sad\" \n",
     "\n",
     "    @field_validator('mood')\n",
     "    @classmethod\n",
@@ -430,7 +430,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "91db3393-b7f8-46e5-8129-0e7539b2804c",
    "metadata": {},
    "outputs": [
@@ -467,7 +467,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "e96c78be-b483-4fa4-949b-62d4274e97ac",
    "metadata": {},
    "outputs": [


### PR DESCRIPTION
The custom validator validate_mood is redundant because the Literal["happy", "sad"] type annotation already provides the necessary validation. 

Pydantic's built-in validation for Literal types is triggered before the custom validator, making the custom validator unnecessary in this case.

We want to highlight usage of custom validators, in general, so we'll just remove Literal.