### PR TITLE
[bug-fix] funky math lesson by llms

### DIFF
--- a/module-1/agent.ipynb
+++ b/module-1/agent.ipynb
@@ -134,8 +134,10 @@
     "\n",
     "tools = [add, multiply, divide]\n",
     "llm = ChatOpenAI(model=\"gpt-4o\")\n",
+    "\n",
     "# For this ipynb we set parallel tool calling to false as math generally is done sequentially\n",
-    "# the OpenAI model specifically defaults to parallel tool calling for eff\n",
+    "# the OpenAI model specifically defaults to parallel tool calling for efficiency, see https://python.langchain.com/docs/how_to/tool_calling_parallel/\n",
+    "# play around with it and see how the model behaves with math equations!\n",
     "llm_with_tools = llm.bind_tools(tools, parallel_tool_calls=False)"
    ]
   },

--- a/module-1/agent.ipynb
+++ b/module-1/agent.ipynb
@@ -135,7 +135,7 @@
     "tools = [add, multiply, divide]\n",
     "llm = ChatOpenAI(model=\"gpt-4o\")\n",
     "\n",
-    "# For this ipynb we set parallel tool calling to false as math generally is done sequentially\n",
+    "# For this ipynb we set parallel tool calling to false as math generally is done sequentially, and this time we have 3 tools that can do math\n",
     "# the OpenAI model specifically defaults to parallel tool calling for efficiency, see https://python.langchain.com/docs/how_to/tool_calling_parallel/\n",
     "# play around with it and see how the model behaves with math equations!\n",
     "llm_with_tools = llm.bind_tools(tools, parallel_tool_calls=False)"

--- a/module-1/agent.ipynb
+++ b/module-1/agent.ipynb
@@ -134,6 +134,8 @@
     "\n",
     "tools = [add, multiply, divide]\n",
     "llm = ChatOpenAI(model=\"gpt-4o\")\n",
+    "# For this ipynb we set parallel tool calling to false as math generally is done sequentially\n",
+    "# the OpenAI model specifically defaults to parallel tool calling for eff\n",
     "llm_with_tools = llm.bind_tools(tools, parallel_tool_calls=False)"
    ]
   },

--- a/module-1/agent.ipynb
+++ b/module-1/agent.ipynb
@@ -134,7 +134,7 @@
     "\n",
     "tools = [add, multiply, divide]\n",
     "llm = ChatOpenAI(model=\"gpt-4o\")\n",
-    "llm_with_tools = llm.bind_tools(tools)"
+    "llm_with_tools = llm.bind_tools(tools, parallel_tool_calls=False)"
    ]
   },
   {

--- a/module-1/chain.ipynb
+++ b/module-1/chain.ipynb
@@ -583,7 +583,7 @@
     }
    ],
    "source": [
-    "messages = graph.invoke({\"messages\": HumanMessage(content=\"Multiply 2 and 3!\")})\n",
+    "messages = graph.invoke({\"messages\": HumanMessage(content=\"Multiply 2 and 3\")})\n",
     "for m in messages['messages']:\n",
     "    m.pretty_print()"
    ]


### PR DESCRIPTION
Hello!

fixes #14, #22.

LLMs and math are funny things sometimes.

- added `parallel_tool_calls=False` to `agents.ipynb` due to the example being math, which is meant to be processed in sequential order not parallelly, I can also add a comment about why we set it to false only for this ipynb, for more clarity.

- when invoking `what is 2 times 3!` in `chain.ipynb`, some models were mathematicians and would treat`3!` as 3 factorial and not excitement, fixed to align with example run output. Unless it was intentional, I can revert changes if so.

thanks for review