### PR TITLE
[Enhance] add platform check to 2 more ipynbs

### DIFF
--- a/module-3/edit-state-human-feedback.ipynb
+++ b/module-3/edit-state-human-feedback.ipynb
@@ -421,6 +421,19 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "020efeba-fa80-4839-81f9-9ce228f9844e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import platform\n",
+    "\n",
+    "if 'google.colab' in str(get_ipython()) or platform.system() != 'Darwin':\n",
+    "    raise Exception(\"Unfortunately LangGraph Studio is currently not supported on Google Colab or requires a Mac\")"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 9,
    "id": "642aabab-f822-4917-9d66-3314ac5008fd",
    "metadata": {},

--- a/module-3/streaming-interruption.ipynb
+++ b/module-3/streaming-interruption.ipynb
@@ -1561,6 +1561,19 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "8925b632-512b-48e1-9220-61c06bfbf0b8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import platform\n",
+    "\n",
+    "if 'google.colab' in str(get_ipython()) or platform.system() != 'Darwin':\n",
+    "    raise Exception(\"Unfortunately LangGraph Studio is currently not supported on Google Colab or requires a Mac\")"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 10,
    "id": "079c2ad6",
    "metadata": {},


### PR DESCRIPTION
Hello!

extension of https://github.com/langchain-ai/langchain-academy/pull/4.

added missing platform check in `streaming-interruption.ipynb` and `edit-human-state-feedback.ipynb`.

simple platform checking
```
import platform

if 'google.colab' in str(get_ipython()) or platform.system() != 'Darwin':
    raise Exception("Unfortunately LangGraph Studio is currently not supported on Google Colab or requires a Mac")
```

thanks for review