### PR TITLE
VSCode DevContainer to simplify environment setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,4 @@
+FROM mcr.microsoft.com/vscode/devcontainers/python:3.11
+
+# Install Jupyter Notebook
+RUN pip install notebook

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+  "name": "Langchain Academy",
+  //container image defined in Dockerfile
+  "dockerFile": "Dockerfile",
+  // configure vscode settings and extensions to use in the devcontainer
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash"
+      },
+      "extensions": [
+        "ms-python.python",
+        "ms-toolsai.jupyter",
+        "ms-azuretools.vscode-docker"
+      ]
+    }
+  },
+  "remoteUser": "vscode",
+  "postCreateCommand": "pip install -r requirements.txt"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,6 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+
+# SQLite data files created during module-2
+example.db-*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+    "editor.formatOnSave": true,
+    "editor.formatOnType": true,
+    "notebook.output.wordWrap": true,
+    "workbench.colorCustomizations": {
+        "titleBar.activeBackground": "#04756f",
+        "titleBar.activeForeground": "#ffffff",
+        "titleBar.inactiveBackground": "#04756f",
+        "titleBar.inactiveForeground": "#000000"
+    }
+}


### PR DESCRIPTION
I recently completed the LangGraph modules - they are great!

# Audience
Those using VSCode with DevContainers extension

# Benefit
Rather than installing the right version of python, jupyter notebook, etc. on my local system - I am installing all of these things in a container and VSCode is using pythong, etc. in that container.

# Notes
This was tested on Windows via WSL with Docker Community installed (avoiding licensing concerns associated with Docker Desktop).  Since this was Windows, I did not perform activities related to LangStudio - so I have not exercised the scenarios where notebooks (running in the container) need to communicate with an application running on the local system (LangStudio)