### PR TITLE
Typo in Module4 (map-reduce.ipynb): Correct 'popular' to 'populate'

### DIFF
--- a/module-4/map-reduce.ipynb
+++ b/module-4/map-reduce.ipynb
@@ -195,7 +195,7 @@
     "\n",
     "`Send` allow you to pass any state that you want to `generate_joke`! It does not have to align with `OverallState`.\n",
     "\n",
-    "In this case, `generate_joke` is using its own internal state, and we can popular this via `Send`."
+    "In this case, `generate_joke` is using its own internal state, and we can populate this via `Send`."
    ]
   },
   {


### PR DESCRIPTION
## Problem
In Module 4, map-reduce.ipynb there is a type. In this case, `generate_joke` is using its own internal state, and we can popular this via `Send`.

## Solution
changed 'popular' to 'populate'.