### PR TITLE
fix(module5-studio): correct langgraph.json filename references for crashing studio

### DIFF
--- a/module-5/studio/langgraph.json
+++ b/module-5/studio/langgraph.json
@@ -1,9 +1,9 @@
 {
     "dockerfile_lines": [],
     "graphs": {
-      "chatbot_memory": "./chatbot_memory.py:graph",
-      "chatbot_memory_profile": "./chatbot_memory_profile.py:graph",
-      "chatbot_memory_collection": "./chatbot_memory_collection.py:graph",
+      "chatbot_memory": "./memory_store.py:graph",
+      "chatbot_memory_profile": "./memoryschema_profile.py:graph",
+      "chatbot_memory_collection": "./memoryschema_collection.py:graph",
       "memory_agent": "./memory_agent.py:graph"
     },
     "env": "./.env",


### PR DESCRIPTION
## Problem
Module 5 LangGraph Studio setup crashed with an error due to incorrect file names in langgraph.json

*Details:*
In Module 5's studio/langgraph.json, the graph keys use incorrect `chatbot_*` prefixes while the actual implementation files use `memory_*` pattern. This mismatch causes LangGraph Studio to fail as it cannot locate the referenced files, blocking learners from proceeding with LangGraph Studuio with the module 5.

## Changes
Fixed incorrect filenames in Module 5's studio/langgraph.json configuration that were causing errors with `LangGraph Studio`.

### Before
Incorrect references:
```json
{
  "chatbot_memory": "./memory_store.py:graph",
  "chatbot_memory_profile": "./memoryschema_profile.py:graph",
  "chatbot_memory_collection": "./memoryschema_collection.py:graph",
  "memory_agent": "./memory_agent.py:graph"
}
```

### After
Updated to match actual implementation:
```json
{
  "memory_store": "./memory_store.py:graph",
  "memory_profile": "./memoryschema_profile.py:graph",
  "memory_collection": "./memoryschema_collection.py:graph",
  "memory_agent": "./memory_agent.py:graph"
}
```

## Testing
✅ Tested in LangGraph Studio
✅ Verified the file references match the actual implementation files
✅ Ensures learners can follow the module without filename confusion

@rlancemartin  @jessicaou 
