### PR TITLE
FIX: revise relative path references in module-5/langgraph.json config

### DIFF
--- a/module-5/studio/langgraph.json
+++ b/module-5/studio/langgraph.json
@@ -1,11 +1,11 @@
 {
     "dockerfile_lines": [],
-    "graphs": {
-      "chatbot_memory": "./chatbot_memory.py:graph",
-      "chatbot_memory_profile": "./chatbot_memory_profile.py:graph",
-      "chatbot_memory_collection": "./chatbot_memory_collection.py:graph",
-      "memory_agent": "./memory_agent.py:graph"
-    },
+   "graphs": {
+		"chatbot_memory": "./memory_store.py:graph",
+		"chatbot_memory_profile": "./memoryschema_profile.py:graph",
+		"chatbot_memory_collection": "./memoryschema_collection.py:graph",
+		"memory_agent": "./memory_agent.py:graph"
+	},
     "env": "./.env",
     "python_version": "3.11",
     "dependencies": [


### PR DESCRIPTION
When the file names in module-5/studio were updated last week, the paths in the langgraph.json file were not updated. Resulting in an error when uploading to Langgraph Studio.