### PR TITLE
Add lc-academy-env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,6 +133,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+lc-academy-env/
 
 # Spyder project settings
 .spyderproject


### PR DESCRIPTION
The readme suggests creating a `venv`. This `venv` doesn't need to be versioned.