### PR TITLE
docs: fixed typo in "module-2/multiple-schemas.ipynb"

### DIFF
--- a/module-2/multiple-schemas.ipynb
+++ b/module-2/multiple-schemas.ipynb
@@ -197,7 +197,7 @@
     "    notes: str\n",
     "\n",
     "def thinking_node(state: OverallState):\n",
-    "    return {\"answer\": \"bye\", \"notes\": \"... his is name is Lance\"}\n",
+    "    return {\"answer\": \"bye\", \"notes\": \"... his name is Lance\"}\n",
     "\n",
     "def answer_node(state: OverallState):\n",
     "    return {\"answer\": \"bye Lance\"}\n",
@@ -232,7 +232,7 @@
     {
      "data": {
       "text/plain": [
-       "{'question': 'hi', 'answer': 'bye Lance', 'notes': '... his is name is Lance'}"
+       "{'question': 'hi', 'answer': 'bye Lance', 'notes': '... his name is Lance'}"
       ]
      },
      "execution_count": 12,


### PR DESCRIPTION
Description: fixed unclear message in node: "... his is name is Lance" -> "... his name is Lance"