### PR TITLE
docs: fix markdown and propose better link for "Conditional Edges" in simple-graph.ipynb

### DIFF
--- a/module-1/simple-graph.ipynb
+++ b/module-1/simple-graph.ipynb
@@ -108,7 +108,7 @@
     "\n",
     "Normal Edges are used if you want to *always* go from, for example, `node_1` to `node_2`.\n",
     "\n",
-    "[Conditional Edges](https://langchain-ai.github.io/langgraph/concepts/low_level/#conditional-edges) are used want to *optionally* route between nodes.\n",
+    "[Conditional Edges](https://langchain-ai.github.io/langgraph/concepts/low_level/#conditional-edges) are used if you want to *optionally* route between nodes.\n",
     " \n",
     "Conditional edges are implemented as functions that return the next node to visit based upon some logic."
    ]

--- a/module-1/simple-graph.ipynb
+++ b/module-1/simple-graph.ipynb
@@ -108,7 +108,7 @@
     "\n",
     "Normal Edges are used if you want to *always* go from, for example, `node_1` to `node_2`.\n",
     "\n",
-    "[Conditional Edges](https://langchain-ai.github.io/langgraph/reference/graphs/?h=conditional+edge#langgraph.graph.StateGraph.add_conditional_edges) are used want to *optionally* route between nodes.\n",
+    "[Conditional Edges](https://langchain-ai.github.io/langgraph/concepts/low_level/#conditional-edges) are used want to *optionally* route between nodes.\n",
     " \n",
     "Conditional edges are implemented as functions that return the next node to visit based upon some logic."
    ]


### PR DESCRIPTION
The original link goes to some generic page on graphs, while this proposed links goes specifically to the section on "Conditional Edges". Seems more useful to a new student.

Also, a few words where missing in the sentence.