### PR TITLE
Fix KeyError: 'tool_calls' when accessing tool call data in chain.ipynb

### DIFF
--- a/module-1/chain.ipynb
+++ b/module-1/chain.ipynb
@@ -329,7 +329,7 @@
     }
    ],
    "source": [
-    "tool_call.additional_kwargs['tool_calls']"
+    "tool_call.additional_kwargs['function_call']"
    ]
   },
   {


### PR DESCRIPTION
This commit addresses a `KeyError: 'tool_calls'` encountered when attempting to access tool call information from the `additional_kwargs` of a tool call object within the `chain.ipynb` notebook.

The issue arose when trying to access `tool_call.additional_kwargs['tool_calls']`, which resulted in a KeyError. Investigation revealed that the tool call information was instead available under the `'function_call'` key in this specific context.

This change ensures the correct key is used to access tool call information, resolving the `KeyError` and allowing for proper access to tool call data within the notebook.