### PR TITLE
Fix link to no longer maintained documentation for Runnable

### DIFF
--- a/module-1/simple-graph.ipynb
+++ b/module-1/simple-graph.ipynb
@@ -210,7 +210,7 @@
    "source": [
     "## Graph Invocation\n",
     "\n",
-    "The compiled graph implements the [runnable](https://python.langchain.com/v0.1/docs/expression_language/interface/) protocol.\n",
+    "The compiled graph implements the [runnable](https://python.langchain.com/docs/concepts/runnables/) protocol.\n",
     "\n",
     "This provides a standard way to execute LangChain components. \n",
     " \n",


### PR DESCRIPTION
Link to 0.1 document shows a red banner : 
"This is documentation for LangChain v0.1, which is no longer actively maintained. Check out the docs for the latest version here"