### PR TITLE
fix(module2-state-schema): fix for last cell of state-schema.ipynb which is breaking on execution

### DIFF
--- a/module-2/state-schema.ipynb
+++ b/module-2/state-schema.ipynb
@@ -446,6 +446,12 @@
     }
    ],
    "source": [
+    "# redefining node_1 since state is an object\n",
+    "def node_1(state):\n",
+    "    print(\"---Node 1---\")\n",
+    "    return {\"name\": state.name + \" is ... \"}\n",
+    "\n",
+    "\n",
     "# Build graph\n",
     "builder = StateGraph(PydanticState)\n",
     "builder.add_node(\"node_1\", node_1)\n",


### PR DESCRIPTION
## Description:
The last cell of state-schema.ipynb is breaking since state comes as PydanticState object rather than a TypeDictState which is a simple dictionary

## Screenshot of error:
