### PR TITLE
Minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,4 +218,8 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+
+# LangGraph API runtime files
+.langgraph_api/
+
 module-6/deployment/docker-compose.yml

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ use a `.env` file with `python-dotenv` library.
 export API_ENV_VAR="your-api-key-here"
 ```
 
-#### Windows Powershell environment variables
+#### On Windows Powershell
 
 ```powershell
 PS> $env:API_ENV_VAR = "your-api-key-here"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $ cd langchain-academy
 
 ### Create an environment and install dependencies
 
-#### Mac/Linux/WSL
+#### Using Mac/Linux/WSL
 
 ```bash
 python3 -m venv lc-academy-env
@@ -38,7 +38,7 @@ source lc-academy-env/bin/activate
 pip install -r requirements.txt
 ```
 
-#### Windows Powershell
+#### Using Windows Powershell
 
 ```powershell
 PS> python3 -m venv lc-academy-env
@@ -60,7 +60,7 @@ jupyter notebook
 Briefly going over how to set up environment variables. You can also
 use a `.env` file with `python-dotenv` library.
 
-#### Mac/Linux/WSL environment variables
+#### On Mac/Linux/WSL
 
 ```bash
 export API_ENV_VAR="your-api-key-here"

--- a/README.md
+++ b/README.md
@@ -1,40 +1,46 @@
-![LangChain Academy](https://cdn.prod.website-files.com/65b8cd72835ceeacd4449a53/66e9eba1020525eea7873f96_LCA-big-green%20(2).svg)
+# ![LangChain Academy](https://cdn.prod.website-files.com/65b8cd72835ceeacd4449a53/66e9eba1020525eea7873f96_LCA-big-green%20(2).svg)
 
 ## Introduction
 
-Welcome to LangChain Academy! 
-This is a growing set of modules focused on foundational concepts within the LangChain ecosystem. 
-Module 0 is basic setup and Modules 1 - 4 focus on LangGraph, progressively adding more advanced themes. 
-In each module folder, you'll see a set of notebooks. A LangChain Academy accompanies each notebook 
-to guide you through the topic. Each module also has a `studio` subdirectory, with a set of relevant 
+Welcome to LangChain Academy!
+This is a growing set of modules focused on foundational concepts within the LangChain ecosystem.
+Module 0 is basic setup and Modules 1 - 4 focus on LangGraph, progressively adding more advanced themes.
+In each module folder, you'll see a set of notebooks. A LangChain Academy accompanies each notebook
+to guide you through the topic. Each module also has a `studio` subdirectory, with a set of relevant
 graphs that we will explore using the LangGraph API and Studio.
 
 ## Setup
 
 ### Python version
 
-To get the most out of this course, please ensure you're using Python 3.11 or later. 
-This version is required for optimal compatibility with LangGraph. If you're on an older version, 
+To get the most out of this course, please ensure you're using Python 3.11 or later.
+This version is required for optimal compatibility with LangGraph. If you're on an older version,
 upgrading will ensure everything runs smoothly.
-```
+
+```bash
 python3 --version
 ```
 
 ### Clone repo
-```
+
+```bash
 git clone https://github.com/langchain-ai/langchain-academy.git
 $ cd langchain-academy
 ```
 
 ### Create an environment and install dependencies
+
 #### Mac/Linux/WSL
+
+```bash
+python3 -m venv lc-academy-env
+source lc-academy-env/bin/activate
+pip install -r requirements.txt
 ```
-$ python3 -m venv lc-academy-env
-$ source lc-academy-env/bin/activate
-$ pip install -r requirements.txt
-```
+
 #### Windows Powershell
-```
+
+```powershell
 PS> python3 -m venv lc-academy-env
 PS> Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope Process
 PS> lc-academy-env\scripts\activate
@@ -42,38 +48,47 @@ PS> pip install -r requirements.txt
 ```
 
 ### Running notebooks
+
 If you don't have Jupyter set up, follow installation instructions [here](https://jupyter.org/install).
-```
-$ jupyter notebook
+
+```bash
+jupyter notebook
 ```
 
 ### Setting up env variables
-Briefly going over how to set up environment variables. You can also 
+
+Briefly going over how to set up environment variables. You can also
 use a `.env` file with `python-dotenv` library.
+
 #### Mac/Linux/WSL
+
+```bash
+export API_ENV_VAR="your-api-key-here"
 ```
-$ export API_ENV_VAR="your-api-key-here"
-```
+
 #### Windows Powershell
-```
+
+```powershell
 PS> $env:API_ENV_VAR = "your-api-key-here"
 ```
 
 ### Set OpenAI API key
+
 * If you don't have an OpenAI API key, you can sign up [here](https://openai.com/index/openai-api/).
-*  Set `OPENAI_API_KEY` in your environment 
+* Set `OPENAI_API_KEY` in your environment
 
 ### Sign up and Set LangSmith API
+
 * Sign up for LangSmith [here](https://smith.langchain.com/), find out more about LangSmith
 * and how to use it within your workflow [here](https://www.langchain.com/langsmith), and relevant library [docs](https://docs.smith.langchain.com/)!
-*  Set `LANGCHAIN_API_KEY`, `LANGCHAIN_TRACING_V2=true` in your environment 
+* Set `LANGCHAIN_API_KEY`, `LANGCHAIN_TRACING_V2=true` in your environment
 
 ### Set up Tavily API for web search
 
-* Tavily Search API is a search engine optimized for LLMs and RAG, aimed at efficient, 
-quick, and persistent search results. 
-* You can sign up for an API key [here](https://tavily.com/). 
-It's easy to sign up and offers a very generous free tier. Some lessons (in Module 4) will use Tavily. 
+* Tavily Search API is a search engine optimized for LLMs and RAG, aimed at efficient,
+quick, and persistent search results.
+* You can sign up for an API key [here](https://tavily.com/).
+It's easy to sign up and offers a very generous free tier. Some lessons (in Module 4) will use Tavily.
 
 * Set `TAVILY_API_KEY` in your environment.
 
@@ -81,16 +96,17 @@ It's easy to sign up and offers a very generous free tier. Some lessons (in Modu
 
 * LangGraph Studio is a custom IDE for viewing and testing agents.
 * Studio can be run locally and opened in your browser on Mac, Windows, and Linux.
-* See documentation [here](https://langchain-ai.github.io/langgraph/concepts/langgraph_studio/#local-development-server) on the local Studio development server and [here](https://langchain-ai.github.io/langgraph/how-tos/local-studio/#run-the-development-server). 
+* See documentation [here](https://langchain-ai.github.io/langgraph/concepts/langgraph_studio/#local-development-server) on the local Studio development server and [here](https://langchain-ai.github.io/langgraph/how-tos/local-studio/#run-the-development-server).
 * Graphs for LangGraph Studio are in the `module-x/studio/` folders.
 * To start the local development server, run the following command in your terminal in the `/studio` directory each module:
 
-```
+```bash
 langgraph dev
 ```
 
 You should see the following output:
-```
+
+```text
 - 🚀 API: http://127.0.0.1:2024
 - 🎨 Studio UI: https://smith.langchain.com/studio/?baseUrl=http://127.0.0.1:2024
 - 📚 API Docs: http://127.0.0.1:2024/docs
@@ -100,7 +116,8 @@ Open your browser and navigate to the Studio UI: `https://smith.langchain.com/st
 
 * To use Studio, you will need to create a .env file with the relevant API keys
 * Run this from the command line to create these files for module 1 to 5, as an example:
-```
+
+```bash
 for i in {1..5}; do
   cp module-$i/studio/.env.example module-$i/studio/.env
   echo "OPENAI_API_KEY=\"$OPENAI_API_KEY\"" > module-$i/studio/.env

--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ jupyter notebook
 Briefly going over how to set up environment variables. You can also
 use a `.env` file with `python-dotenv` library.
 
-#### Mac/Linux/WSL
+#### Mac/Linux/WSL environment variables
 
 ```bash
 export API_ENV_VAR="your-api-key-here"
 ```
 
-#### Windows Powershell
+#### Windows Powershell environment variables
 
 ```powershell
 PS> $env:API_ENV_VAR = "your-api-key-here"

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ PS> pip install -r requirements.txt
 
 ### Running notebooks
 
-If you don't have Jupyter set up, follow installation instructions [here](https://jupyter.org/install).
+If you don't have Jupyter set up, follow [Jupyter installation instructions](https://jupyter.org/install).
 
 ```bash
 jupyter notebook
@@ -74,20 +74,20 @@ PS> $env:API_ENV_VAR = "your-api-key-here"
 
 ### Set OpenAI API key
 
-* If you don't have an OpenAI API key, you can sign up [here](https://openai.com/index/openai-api/).
+* If you don't have an OpenAI API key, you can [sign up for OpenAI API](https://openai.com/index/openai-api/).
 * Set `OPENAI_API_KEY` in your environment
 
 ### Sign up and Set LangSmith API
 
-* Sign up for LangSmith [here](https://smith.langchain.com/), find out more about LangSmith
-* and how to use it within your workflow [here](https://www.langchain.com/langsmith), and relevant library [docs](https://docs.smith.langchain.com/)!
+* [Sign up for LangSmith](https://smith.langchain.com/), find out more about LangSmith
+* and how to use it within your workflow [on the LangSmith website](https://www.langchain.com/langsmith), and relevant library [docs](https://docs.smith.langchain.com/)!
 * Set `LANGCHAIN_API_KEY`, `LANGCHAIN_TRACING_V2=true` in your environment
 
 ### Set up Tavily API for web search
 
 * Tavily Search API is a search engine optimized for LLMs and RAG, aimed at efficient,
 quick, and persistent search results.
-* You can sign up for an API key [here](https://tavily.com/).
+* You can [sign up for a Tavily API key](https://tavily.com/).
 It's easy to sign up and offers a very generous free tier. Some lessons (in Module 4) will use Tavily.
 
 * Set `TAVILY_API_KEY` in your environment.
@@ -96,7 +96,7 @@ It's easy to sign up and offers a very generous free tier. Some lessons (in Modu
 
 * LangGraph Studio is a custom IDE for viewing and testing agents.
 * Studio can be run locally and opened in your browser on Mac, Windows, and Linux.
-* See documentation [here](https://langchain-ai.github.io/langgraph/concepts/langgraph_studio/#local-development-server) on the local Studio development server and [here](https://langchain-ai.github.io/langgraph/how-tos/local-studio/#run-the-development-server).
+* See documentation [on the local Studio development server](https://langchain-ai.github.io/langgraph/concepts/langgraph_studio/#local-development-server) and [how to run the development server](https://langchain-ai.github.io/langgraph/how-tos/local-studio/#run-the-development-server).
 * Graphs for LangGraph Studio are in the `module-x/studio/` folders.
 * To start the local development server, run the following command in your terminal in the `/studio` directory each module:
 


### PR DESCRIPTION
This PR contains fixes several Markdown linting errors in README.md:
  - MD009/no-trailing-spaces: Trailing spaces [Expected: 0 or 2; Actual: 1] [MD009](https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md009.md)
  - MD014/commands-show-output: Dollar signs used before commands without showing output [MD014](https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md014.md)
  - MD022/blanks-around-headings: Headings should be surrounded by blank lines [Expected: 1; Actual: 0; Below] [MD022](https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md022.md)
  - MD024/no-duplicate-heading: Multiple headings with the same content MD024](https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md024.md)
  - MD030/list-marker-space: Spaces after list markers [Expected: 1; Actual: 2] [MD030](https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md030.md)
  - MD031/blanks-around-fences: Fenced code blocks should be surrounded by blank lines [MD031](https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md031.md)
  - MD032/blanks-around-lists: Lists should be surrounded by blank lines [MD032](https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md032.md)
  - MD040/fenced-code-language: Fenced code blocks should have a language specified [MD040](https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md040.md)
  - MD041/first-line-heading/first-line-h1: First line in a file should be a top-level heading [MD041](https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md041.md)
  - MD059/descriptive-link-text: Link text should be descriptive [MD059](https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md059.md)