### PR TITLE
Fix conditional edge missing literal issue, same as #126

### DIFF
--- a/module-3/streaming-interruption.ipynb
+++ b/module-3/streaming-interruption.ipynb
@@ -77,7 +77,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "2d7321e0-0d99-4efe-a67b-74c12271859b",
    "metadata": {},
    "outputs": [
@@ -102,6 +102,7 @@
     "from langgraph.checkpoint.memory import MemorySaver\n",
     "from langgraph.graph import StateGraph, START, END\n",
     "from langgraph.graph import MessagesState\n",
+    "from typing_extensions import Literal\n",
     "\n",
     "# LLM\n",
     "model = ChatOpenAI(model=\"gpt-4o\", temperature=0) \n",
@@ -157,8 +158,7 @@
     "    return {\"summary\": response.content, \"messages\": delete_messages}\n",
     "\n",
     "# Determine whether to end or summarize the conversation\n",
-    "def should_continue(state: State):\n",
-    "    \n",
+    "def should_continue(state: State) -> Literal [\"summarize_conversation\",END]:    \n",
     "    \"\"\"Return the next node to execute.\"\"\"\n",
     "    \n",
     "    messages = state[\"messages\"]\n",


### PR DESCRIPTION
same as issue #126, the streaming-interruption.ipynb failed to display the graph.

modification:
from
`def should_continue(state: State)`
to
`def should_continue(state: State) -> Literal ["summarize_conversation", END]:`