### PR TITLE
Fix: There was a typo- supply word was duplicated, which has been fixed

### DIFF
--- a/module-5/memoryschema_profile.ipynb
+++ b/module-5/memoryschema_profile.ipynb
@@ -625,7 +625,7 @@
    "source": [
     "We use `create_extractor`, passing in the model as well as our schema as a [tool](https://python.langchain.com/docs/concepts/tools/).\n",
     "\n",
-    "With TrustCall, can supply supply the schema in various ways. \n",
+    "With TrustCall, can supply the schema in various ways. \n",
     "\n",
     "For example, we can pass a JSON object / Python dictionary or Pydantic model.\n",
     "\n",


### PR DESCRIPTION
Documentation Typo: Documentation typo was noticed in memoryshema_profile.jpynb(supply word was duplicated). 
Fix: Removed the duplicate supply word