### PR TITLE
Fix devcontainer persistence and add port forwarding

### DIFF
--- a/.devcontainer/.env.example
+++ b/.devcontainer/.env.example
@@ -1,0 +1,12 @@
+# LangSmith
+LANGSMITH_API_KEY=lsv2_xxx
+LANGSMITH_TRACING_V2=true
+LANGSMITH_PROJECT=langchain-academy
+# If you are on the EU instance also set
+# LANGSMITH_ENDPOINT=https://eu.api.smith.langchain.com
+
+# OpenAI
+OPENAI_API_KEY=sk-xxx
+
+# Tavily
+TAVILY_API_KEY=tvly-xxx

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,8 @@
 FROM mcr.microsoft.com/devcontainers/python:1-3.11-bookworm
 
-# Install LangGraph Studio
-RUN pip install langgraph-cli[inmem]
+# Install JupyterLab and LangGraph Studio
+RUN pip install jupyterlab langgraph-cli[inmem]
 
-# Copy and install requirements (includes jupyterlab, notebook)
+# Install requirements
 COPY requirements.txt /tmp/requirements.txt
 RUN pip install -r /tmp/requirements.txt && rm /tmp/requirements.txt

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,8 @@
+FROM mcr.microsoft.com/devcontainers/python:1-3.11-bookworm
+
+# Install LangGraph Studio
+RUN pip install langgraph-cli[inmem]
+
+# Copy and install requirements (includes jupyterlab, notebook)
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install -r /tmp/requirements.txt && rm /tmp/requirements.txt

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,9 @@
+# Dev Container Setup
+
+Before starting the dev container, create your `.env` file:
+
+```bash
+cp .devcontainer/.env.example .devcontainer/.env
+```
+
+Then edit `.devcontainer/.env` and add your API keys.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,8 +2,19 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/python
 {
 	"name": "Python 3",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/python:1-3.11-bookworm",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"context": ".."
+	},
+	"forwardPorts": [
+		8888,	// jupyter
+		2024	// langsmith 
+	],
+
+	// Load environment variables from .env file
+	"runArgs": [
+		"--env-file", "${localWorkspaceFolder}/.devcontainer/.env"
+	]
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
@@ -12,7 +23,7 @@
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "pip install jupyterlab && pip3 install --user -r requirements.txt",
+	// "postCreateCommand": "",
 
 	// Configure tool-specific properties.
 	// "customizations": {},


### PR DESCRIPTION
## Summary
- Move dependency installation to Dockerfile so packages persist across container restarts and rebuilds
- Add port forwarding for Jupyter (8888) and LangSmith (2024)
- Add .env.example with required API keys