### PR TITLE
fix: patch 13 medium-severity security alerts (3 packages)

### DIFF
--- a/module-1/studio/requirements.txt
+++ b/module-1/studio/requirements.txt
@@ -1,6 +1,7 @@
 langgraph
 langgraph-prebuilt
-langchain-core
+langchain-core>=1.2.28
 langchain-community
 langchain-openai
+langsmith>=0.7.31
 aiohttp>=3.13.4

--- a/module-2/studio/requirements.txt
+++ b/module-2/studio/requirements.txt
@@ -1,5 +1,6 @@
 langgraph
-langchain-core
+langchain-core>=1.2.28
 langchain-community
 langchain-openai
+langsmith>=0.7.31
 aiohttp>=3.13.4

--- a/module-3/studio/requirements.txt
+++ b/module-3/studio/requirements.txt
@@ -1,6 +1,7 @@
 langgraph
 langgraph-prebuilt
-langchain-core
+langchain-core>=1.2.28
 langchain-community
 langchain-openai
+langsmith>=0.7.31
 aiohttp>=3.13.4

--- a/module-5/studio/requirements.txt
+++ b/module-5/studio/requirements.txt
@@ -1,6 +1,7 @@
 langgraph
-langchain-core
+langchain-core>=1.2.28
 langchain-community
 langchain-openai
 trustcall
+langsmith>=0.7.31
 aiohttp>=3.13.4

--- a/module-6/deployment/requirements.txt
+++ b/module-6/deployment/requirements.txt
@@ -1,6 +1,7 @@
 langgraph
-langchain-core
+langchain-core>=1.2.28
 langchain-community
 langchain-openai
 trustcall
+langsmith>=0.7.31
 aiohttp>=3.13.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,9 @@ langgraph
 langgraph-prebuilt
 langgraph-sdk
 langgraph-checkpoint-sqlite
-langsmith
+langsmith>=0.7.31
 langchain-community
-langchain-core
+langchain-core>=1.2.28
 langchain-openai
 notebook
 langchain-tavily
@@ -14,4 +14,4 @@ langgraph-cli[inmem]
 
 aiohttp>=3.13.4
 Pygments>=2.20.0
-cryptography>=46.0.6
+cryptography>=46.0.7


### PR DESCRIPTION
## Security Alert Patch

Resolves 13 Dependabot security alerts in the **medium** severity tier.

### Packages Updated

| Package | Old Constraint | New Constraint | Strategy | Scope | CVEs Resolved |
|---------|---------------|----------------|----------|-------|---------------|
| `langchain-core` | unpinned | `>=1.2.28` | A (direct bump) | runtime | CVE-2026-40087 / GHSA-926x-3r5x-gfhw |
| `langsmith` | unpinned | `>=0.7.31` | A (direct bump / add floor) | runtime | GHSA-rr7j-v2q5-chgv |
| `cryptography` | `>=46.0.6` | `>=46.0.7` | A (direct bump) | runtime | CVE-2026-39892 / GHSA-p423-j2cm-9vmq |

Strategy = direct bump (A)

### CVE Details

- **CVE-2026-40087 / GHSA-926x-3r5x-gfhw** — `langchain-core`: Incomplete f-string validation in prompt templates. Fixed in `>=1.2.28`.
- **GHSA-rr7j-v2q5-chgv** — `langsmith`: Streaming token events bypass output redaction. Fixed in `>=0.7.31`.
- **CVE-2026-39892 / GHSA-p423-j2cm-9vmq** — `cryptography`: Buffer overflow if non-contiguous buffers were passed to APIs. Fixed in `>=46.0.7`.

### Linear Tickets

No matching Linear tickets found for the resolved CVEs.

### Manifests Modified

- `requirements.txt` (root) — all 3 packages
- `module-1/studio/requirements.txt` — langchain-core, langsmith
- `module-2/studio/requirements.txt` — langchain-core, langsmith
- `module-3/studio/requirements.txt` — langchain-core, langsmith
- `module-5/studio/requirements.txt` — langchain-core, langsmith
- `module-6/deployment/requirements.txt` — langchain-core, langsmith

### Verification

- [x] No lockfiles to regenerate (plain requirements.txt repo)
- [x] No lint/test infrastructure in repo — changes are syntactically valid version pins

🤖 Submitted by langster-patch