### PR TITLE
fix: patch 12 security alerts (medium + low severity)

### DIFF
--- a/module-1/studio/requirements.txt
+++ b/module-1/studio/requirements.txt
@@ -2,6 +2,7 @@ langgraph
 langgraph-prebuilt
 langchain-core>=1.2.28
 langchain-community
-langchain-openai
+langchain-openai>=1.1.14
+langchain-text-splitters>=1.1.2
 langsmith>=0.7.31
 aiohttp>=3.13.4

--- a/module-2/studio/requirements.txt
+++ b/module-2/studio/requirements.txt
@@ -1,6 +1,7 @@
 langgraph
 langchain-core>=1.2.28
 langchain-community
-langchain-openai
+langchain-openai>=1.1.14
+langchain-text-splitters>=1.1.2
 langsmith>=0.7.31
 aiohttp>=3.13.4

--- a/module-3/studio/requirements.txt
+++ b/module-3/studio/requirements.txt
@@ -2,6 +2,7 @@ langgraph
 langgraph-prebuilt
 langchain-core>=1.2.28
 langchain-community
-langchain-openai
+langchain-openai>=1.1.14
+langchain-text-splitters>=1.1.2
 langsmith>=0.7.31
 aiohttp>=3.13.4

--- a/module-5/studio/requirements.txt
+++ b/module-5/studio/requirements.txt
@@ -1,7 +1,8 @@
 langgraph
 langchain-core>=1.2.28
 langchain-community
-langchain-openai
+langchain-openai>=1.1.14
+langchain-text-splitters>=1.1.2
 trustcall
 langsmith>=0.7.31
 aiohttp>=3.13.4

--- a/module-6/deployment/requirements.txt
+++ b/module-6/deployment/requirements.txt
@@ -1,7 +1,8 @@
 langgraph
 langchain-core>=1.2.28
 langchain-community
-langchain-openai
+langchain-openai>=1.1.14
+langchain-text-splitters>=1.1.2
 trustcall
 langsmith>=0.7.31
 aiohttp>=3.13.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,8 @@ langgraph-checkpoint-sqlite
 langsmith>=0.7.31
 langchain-community
 langchain-core>=1.2.28
-langchain-openai
+langchain-openai>=1.1.14
+langchain-text-splitters>=1.1.2
 notebook
 langchain-tavily
 wikipedia


### PR DESCRIPTION
## Security Alert Patch

Resolves 12 Dependabot security alerts in the medium + low severity tier (no critical or high alerts are open).

### Packages Updated

| Package | Old Constraint | New Constraint | Strategy | Scope | CVEs Resolved |
|---------|---------------|----------------|----------|-------|---------------|
| `langchain-openai` | unpinned | `>=1.1.14` | A (direct pin) | runtime | GHSA-r7w7-9xr2-qq2r |
| `langchain-text-splitters` | (transitive, unpinned) | `>=1.1.2` | A (add direct pin) | runtime | GHSA-fv5p-p927-qmxr |

Strategy = direct bump (A) / lockfile-only (A-lockfile) / parent bump (B) / override (C)
Scope = runtime (installed when `pip install -r requirements.txt` runs)

Both bumps are patch-level within the existing `1.x` line — no major-version boundary is crossed and no breaking changes are introduced.

### Manifests Updated

- `requirements.txt`
- `module-1/studio/requirements.txt`
- `module-2/studio/requirements.txt`
- `module-3/studio/requirements.txt`
- `module-5/studio/requirements.txt`
- `module-6/deployment/requirements.txt`

### Upstream Issues

None — both packages have released patched versions and the fix is applied directly.

### CVE Details

- **GHSA-r7w7-9xr2-qq2r** (low) — \`langchain-openai\`: Image token counting SSRF protection can be bypassed via DNS rebinding. Fixed in \`1.1.14\`. https://github.com/advisories/GHSA-r7w7-9xr2-qq2r
- **GHSA-fv5p-p927-qmxr** (medium) — \`langchain-text-splitters\`: \`HTMLHeaderTextSplitter.split_text_from_url\` SSRF redirect bypass. Fixed in \`1.1.2\`. https://github.com/advisories/GHSA-fv5p-p927-qmxr

### Linear Tickets

No matching Linear tickets found for the resolved GHSAs.

### Verification

- [x] Requirements files syntactically valid (PEP 508)
- [x] No lockfiles to regenerate (requirements.txt-only repo)
- [x] gitleaks scan on staged changes — no leaks
- [x] No test suite or linters configured in repo

🤖 Submitted by langster-patch