### PR TITLE
fix(module-4): use langchain-tavily instead of nonexistent langgraph-…

### DIFF
--- a/module-4/parallelization.ipynb
+++ b/module-4/parallelization.ipynb
@@ -54,7 +54,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "618eab5c-4ef7-4273-8e0b-a9c847897ed7",
    "metadata": {
     "editable": true,
@@ -66,7 +66,7 @@
    "outputs": [],
    "source": [
     "%%capture --no-stderr\n",
-    "%pip install -U  langgraph langgraph_tavily wikipedia langchain_openai langchain_community langgraph_sdk"
+    "%pip install -U  langgraph langchain-tavily wikipedia langchain_openai langchain_community langgraph_sdk"
    ]
   },
   {


### PR DESCRIPTION
The `%pip install` cell in `module-4/parallelization.ipynb` references `langgraph-tavily`, which does not exist on PyPI. The cell fails on fresh installs with:

Fixes #167