### PR TITLE
docs: fix typo and refresh stale cached output in module-2/multiple-s…

### DIFF
--- a/module-2/multiple-schemas.ipynb
+++ b/module-2/multiple-schemas.ipynb
@@ -309,7 +309,7 @@
     {
      "data": {
       "text/plain": [
-       "{'question': 'hi', 'answer': 'bye Lance', 'notes': '... his is name is Lance'}"
+       "{'answer': 'bye Lance'}"
       ]
      },
      "execution_count": 7,
@@ -330,7 +330,7 @@
     "    notes: str\n",
     "\n",
     "def thinking_node(state: InputState):\n",
-    "    return {\"answer\": \"bye\", \"notes\": \"... his is name is Lance\"}\n",
+    "    return {\"answer\": \"bye\", \"notes\": \"... his name is Lance\"}\n",
     "\n",
     "def answer_node(state: OverallState) -> OutputState:\n",
     "    return {\"answer\": \"bye Lance\"}\n",


### PR DESCRIPTION
## Description

  Cell 12 of `module-2/multiple-schemas.ipynb` (the `input_schema=InputState, output_schema=OutputState` example) has two
  related issues:

  1. **Source typo** in `thinking_node`: `"... his is name is Lance"` → `"... his name is Lance"`. Sibling typo to the one
  fixed for cell 8 in #67 — apparently missed because both cells had the same string.

  2. **Stale cached output**: the cell's cached `execute_result` shows `{'question': 'hi', 'answer': 'bye Lance', 'notes': '...
   his is name is Lance'}` (3 fields, pre-`output_schema` behavior). Running the cell with the current code produces
  `{'answer': 'bye Lance'}` — `output_schema=OutputState` filters `notes`/`question` out. The cached output was never refreshed
   when `input_schema`/`output_schema` were introduced.

  This contradicts the markdown immediately after the cell ("We can see the `output` schema constrains the output to only the
  `answer` key"), which can confuse learners reading the notebook without running it.

  ## Test plan

  - Re-ran cell 12 with `nbclient` end-to-end against the current LangGraph version — output matches the new cached value
  (`{'answer': 'bye Lance'}`) exactly.